### PR TITLE
Fix for bottomPlaceholder not being shown in some situations

### DIFF
--- a/DraggableItem.qml
+++ b/DraggableItem.qml
@@ -130,6 +130,7 @@ Item {
             right: parent.right
             top: wrapperParent.verticalCenter
         }
+        enabled: !dragArea.drag.active
         property bool isLast: model.index === _listView.count - 1
         height: isLast ? _listView.contentHeight - y : contentItem.height
 


### PR DESCRIPTION
Disable the bottomDropArea for the dragged item since it interfered
with transition between bottomDragAreas above/below bottomDragArea
for the dragged item when dragging upwards. This resulted in no
bottomPlaceHolder being displayed when passing
this position in the listview.

The problem can be visualized by adding the following code to
bottomDropArea:

Rectangle {
   anchors.fill: parent
   anchors.margins: 1
   color: "transparent"
   border.width: 1
   border.color: dragArea.drag.active ? "green" : "red"
}