### PR TITLE
Adds an additional null check to when clause of "droppingAbove" state…

### DIFF
--- a/DraggableItem.qml
+++ b/DraggableItem.qml
@@ -184,7 +184,7 @@ Item {
             }
         },
         State {
-            when: topDropAreaLoader.item.containsDrag
+            when: topDropAreaLoader.item !== null ? topDropAreaLoader.item.containsDrag : false
             name: "droppingAbove"
             PropertyChanges {
                 target: topPlaceholder


### PR DESCRIPTION
… to avoid the following warning...

"qrc:/DraggableItem.qml:187: TypeError: Cannot read property 'containsDrag' of null"